### PR TITLE
Fixed issue with unused lambda capture

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -34,7 +34,7 @@ Tester::Tester(QWidget* parent)
     });
 
     //Syntax to connect a custom class signal with a lambda.
-    QObject::connect(this, &Tester::sigLabelTextUpdated, this, [this](std::string_view val){
+    QObject::connect(this, &Tester::sigLabelTextUpdated, this, [](std::string_view val){
         std::cout << val << std::endl;
     });
 }


### PR DESCRIPTION
Error on line 65: in lambda expression causes the build to fail when building on clang with -Wunused-lambda-capture flag.

The error is caused by the below line of code:
```c++
QObject::connect(this, &Tester::sigLabelTextUpdated, this, [this](std::string_view val){
        std::cout << val << std::endl;
    });
```

There's no real need to capture `[this]` in the lambda expression, as it is unused.